### PR TITLE
fix: reject pending resolvers when flow $end() is called

### DIFF
--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -2299,6 +2299,53 @@ describe('flow', () => {
     })
   })
 
+  describe('$end() with pending dependency resolvers', () => {
+    it('should not hang when $end() is called and other tasks are waiting on the ended task', async () => {
+      const f = await flow<undefined>({
+        async anonId() {
+          const anonId = null // simulate no anon ID
+          if (!anonId) {
+            this.$end(undefined)
+          }
+          return anonId!
+        },
+        async ip() {
+          return 'ip-value'
+        },
+        async claimChats() {
+          await this.$.anonId
+          return 'claimed'
+        },
+        async deleteId() {
+          await this.$.anonId
+          return 'deleted'
+        },
+        async track() {
+          await this.$.anonId
+          await this.$.ip
+          return 'tracked'
+        },
+      })
+
+      expect(f).toBeUndefined()
+    }, 1000) // 1s timeout - will fail if deadlocked
+
+    it('should not hang when $end() is called before dependent tasks call waitForDep', async () => {
+      const f = await flow<string>({
+        async fast() {
+          this.$end('done')
+        },
+        async slow() {
+          await sleep(50) // sleep so fast() has already called $end
+          await this.$.fast // should not hang
+          return 'slow-result'
+        },
+      })
+
+      expect(f).toBe('done')
+    }, 1000)
+  })
+
   describe('External signal integration', () => {
     it('should respect external abort signal', async () => {
       const controller = new AbortController()

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -368,7 +368,9 @@ function executeTasksInternal<T extends Record<string, any>>(
       // In flow mode, handle FlowEndError and FlowAbortedError specially
       if (options.flowMode) {
         if (err instanceof FlowEndError) {
-          // This is intentional early exit, don't propagate as error
+          // This is intentional early exit, don't propagate as error.
+          // Reject pending resolvers so dependent tasks don't hang forever.
+          handleError(name, new FlowAbortedError())
           return
         }
         if (err instanceof FlowAbortedError) {


### PR DESCRIPTION
When a task calls `this.$end()`, the `FlowEndError` catch handler returns without calling `handleResult` or `handleError`. This means any tasks already waiting on that task's resolver promise hang forever, since the promise is never settled.

Because `flow` uses `Promise.allSettled(promises)`, it waits for all task promises to complete — but the hung tasks never complete, causing the entire `flow()` call to never resolve (function timeout).

The fix calls `handleError(name, new FlowAbortedError())` before returning from the `FlowEndError` handler, which rejects all pending resolver promises and unblocks dependent tasks.