### PR TITLE
Add a tracing hook for task execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Pass a `trace` callback to instrument the complete execution graph without
 coupling `better-all` to a specific tracing library:
 
 ```typescript
+import { SpanStatusCode, trace as openTelemetry } from '@opentelemetry/api'
 import {
   all,
   type ExecutionTraceEvent,
@@ -326,22 +327,53 @@ function formatTraceName(event: ExecutionTraceEvent) {
     return `better-all.${event.operation}`
   }
   if (event.type === 'task') {
-    return `better-all.${event.operation}.task.${event.task}`
+    return 'better-all.task'
   }
-  return `better-all.${event.operation}.wait.${event.task}.${event.dependency}`
+  return 'better-all.dependency-wait'
 }
 
-const trace: ExecutionTracer = async (event, run) => {
-  const span = tracer.startSpan(formatTraceName(event))
-  try {
-    return await run()
-  } catch (error) {
-    span.recordException(error)
-    throw error
-  } finally {
-    span.end()
+function formatTraceAttributes(
+  event: ExecutionTraceEvent,
+): Record<string, string> {
+  const attributes = {
+    'better_all.operation': event.operation,
+  }
+
+  if (event.type === 'execution') {
+    return attributes
+  }
+
+  if (event.type === 'task') {
+    return {
+      ...attributes,
+      'better_all.task': event.task,
+    }
+  }
+
+  return {
+    ...attributes,
+    'better_all.task': event.task,
+    'better_all.dependency': event.dependency,
   }
 }
+
+const tracer = openTelemetry.getTracer('app')
+const trace: ExecutionTracer = (event, run) =>
+  tracer.startActiveSpan(
+    formatTraceName(event),
+    { attributes: formatTraceAttributes(event) },
+    async (span) => {
+      try {
+        return await run()
+      } catch (error) {
+        span.recordException(error as Error)
+        span.setStatus({ code: SpanStatusCode.ERROR })
+        throw error
+      } finally {
+        span.end()
+      }
+    },
+  )
 
 const result = await all(
   {
@@ -364,7 +396,9 @@ The callback receives:
 
 The callback must return the result of `run` and preserve rejected promises.
 This allows tracing adapters to create correctly nested spans and record errors
-without changing execution behavior.
+without changing execution behavior. When using OpenTelemetry, use
+`startActiveSpan` or explicitly activate the span context so nested tasks and
+dependency waits inherit the correct parent.
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ yarn add better-all
 - **No hanging promises**: Avoids the uncaught dangling promises problem often seen in manual optimization
 - **Auto-abort on failure**: Cancel remaining tasks when one fails via `this.$signal`
 - **Debug mode with waterfall visualization**: See exactly how tasks execute with ASCII waterfall charts
+- **Execution tracing**: Instrument executions, tasks, and dependency waits with any tracing library
 - **Early exit support**: Exit flows early when a result is determined
 - **Lightweight**: Minimal dependencies and small bundle size
 
@@ -108,6 +109,7 @@ Execute tasks with automatic dependency resolution.
 - `options`: Optional configuration object
   - `debug`: Set to `true` to output a waterfall chart showing task execution timeline
   - `signal`: An `AbortSignal` to abort all tasks externally
+  - `trace`: A callback for tracing the execution, each task, and dependency waits
 - Each task function receives:
   - `this.$` - an object with promises for all task results
   - `this.$signal` - an `AbortSignal` that aborts when any sibling task fails
@@ -122,6 +124,7 @@ Execute tasks with automatic dependency resolution, returning settled results fo
 - `options`: Optional configuration object
   - `debug`: Set to `true` to output a waterfall chart showing task execution timeline
   - `signal`: An `AbortSignal` to abort all tasks externally
+  - `trace`: A callback for tracing the execution, each task, and dependency waits
 - Each task function receives:
   - `this.$` - an object with promises for all task results
   - `this.$signal` - an `AbortSignal` (only aborts on external signal, not on sibling failure)
@@ -305,6 +308,63 @@ This makes it easy to:
 - See exactly how long each task actively executes vs waits
 - Understand the dependency chain and blocking relationships
 - Spot opportunities for optimization (e.g., tasks with long wait times)
+
+## Execution Tracing
+
+Pass a `trace` callback to instrument the complete execution graph without
+coupling `better-all` to a specific tracing library:
+
+```typescript
+import {
+  all,
+  type ExecutionTraceEvent,
+  type ExecutionTracer,
+} from 'better-all'
+
+function formatTraceName(event: ExecutionTraceEvent) {
+  if (event.type === 'execution') {
+    return `better-all.${event.operation}`
+  }
+  if (event.type === 'task') {
+    return `better-all.${event.operation}.task.${event.task}`
+  }
+  return `better-all.${event.operation}.wait.${event.task}.${event.dependency}`
+}
+
+const trace: ExecutionTracer = async (event, run) => {
+  const span = tracer.startSpan(formatTraceName(event))
+  try {
+    return await run()
+  } catch (error) {
+    span.recordException(error)
+    throw error
+  } finally {
+    span.end()
+  }
+}
+
+const result = await all(
+  {
+    async user() {
+      return fetchUser()
+    },
+    async posts() {
+      return fetchPosts((await this.$.user).id)
+    },
+  },
+  { trace },
+)
+```
+
+The callback receives:
+
+- `execution` for the complete `all`, `allSettled`, or `flow` call
+- `task` for each task's full lifetime
+- `dependency-wait` each time a task accesses `this.$.<dependency>`
+
+The callback must return the result of `run` and preserve rejected promises.
+This allows tracing adapters to create correctly nested spans and record errors
+without changing execution behavior.
 
 ## Error Handling
 

--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
 import { describe, it, expect, vi, expectTypeOf } from 'vitest'
 import {
   all,
@@ -17,6 +18,11 @@ type TraceRecord = {
   event: ExecutionTraceEvent
 }
 
+type TraceRelation = {
+  event: ExecutionTraceEvent
+  parent: ExecutionTraceEvent | undefined
+}
+
 function createRecordingTracer(records: TraceRecord[]): ExecutionTracer {
   return async (event, run) => {
     records.push({ phase: 'start', event })
@@ -28,6 +34,15 @@ function createRecordingTracer(records: TraceRecord[]): ExecutionTracer {
       records.push({ phase: 'error', event })
       throw error
     }
+  }
+}
+
+function createContextTracer(relations: TraceRelation[]): ExecutionTracer {
+  const context = new AsyncLocalStorage<ExecutionTraceEvent>()
+
+  return (event, run) => {
+    relations.push({ event, parent: context.getStore() })
+    return context.run(event, run)
   }
 }
 
@@ -1104,6 +1119,63 @@ describe('allSettled', () => {
 })
 
 describe('Tracing', () => {
+  it('preserves parent context for tasks and dependency waits', async () => {
+    const relations: TraceRelation[] = []
+
+    await all(
+      {
+        async source() {
+          await sleep(5)
+          return 1
+        },
+        async dependent() {
+          return (await this.$.source) + 1
+        },
+      },
+      { trace: createContextTracer(relations) },
+    )
+
+    const execution = {
+      type: 'execution',
+      operation: 'all',
+      tasks: ['source', 'dependent'],
+    } satisfies ExecutionTraceEvent
+
+    expect(relations).toContainEqual({
+      event: execution,
+      parent: undefined,
+    })
+    expect(relations).toContainEqual({
+      event: {
+        type: 'task',
+        operation: 'all',
+        task: 'source',
+      },
+      parent: execution,
+    })
+    expect(relations).toContainEqual({
+      event: {
+        type: 'task',
+        operation: 'all',
+        task: 'dependent',
+      },
+      parent: execution,
+    })
+    expect(relations).toContainEqual({
+      event: {
+        type: 'dependency-wait',
+        operation: 'all',
+        task: 'dependent',
+        dependency: 'source',
+      },
+      parent: {
+        type: 'task',
+        operation: 'all',
+        task: 'dependent',
+      },
+    })
+  })
+
   it('traces the execution, tasks, and dependency waits', async () => {
     const records: TraceRecord[] = []
 
@@ -1154,6 +1226,161 @@ describe('Tracing', () => {
     expect(records.filter((record) => record.phase === 'end')).toHaveLength(
       startedEvents.length,
     )
+  })
+
+  it('reports task and execution failures from all', async () => {
+    const records: TraceRecord[] = []
+    const failure = new Error('failed')
+
+    await expect(
+      all(
+        {
+          failed() {
+            throw failure
+          },
+        },
+        { trace: createRecordingTracer(records) },
+      ),
+    ).rejects.toBe(failure)
+
+    expect(
+      records
+        .filter((record) => record.phase === 'error')
+        .map((record) => record.event),
+    ).toEqual([
+      {
+        type: 'task',
+        operation: 'all',
+        task: 'failed',
+      },
+      {
+        type: 'execution',
+        operation: 'all',
+        tasks: ['failed'],
+      },
+    ])
+  })
+
+  it('reports unknown dependency access at every tracing level', async () => {
+    const records: TraceRecord[] = []
+
+    await expect(
+      all(
+        {
+          async task() {
+            const dependencies = this.$ as unknown as Record<
+              string,
+              Promise<unknown>
+            >
+            return await dependencies.missing
+          },
+        },
+        { trace: createRecordingTracer(records) },
+      ),
+    ).rejects.toThrow('Unknown task "missing"')
+
+    expect(
+      records
+        .filter((record) => record.phase === 'error')
+        .map((record) => record.event),
+    ).toEqual([
+      {
+        type: 'dependency-wait',
+        operation: 'all',
+        task: 'task',
+        dependency: 'missing',
+      },
+      {
+        type: 'task',
+        operation: 'all',
+        task: 'task',
+      },
+      {
+        type: 'execution',
+        operation: 'all',
+        tasks: ['task'],
+      },
+    ])
+  })
+
+  it('traces each access to the same dependency', async () => {
+    const records: TraceRecord[] = []
+
+    const result = await all(
+      {
+        async source() {
+          await sleep(5)
+          return 2
+        },
+        async dependent() {
+          const [first, second] = await Promise.all([
+            this.$.source,
+            this.$.source,
+          ])
+          return first + second
+        },
+      },
+      { trace: createRecordingTracer(records) },
+    )
+
+    expect(result.dependent).toBe(4)
+
+    const dependencyRecords = records.filter(
+      (record) =>
+        record.event.type === 'dependency-wait' &&
+        record.event.task === 'dependent' &&
+        record.event.dependency === 'source',
+    )
+    expect(
+      dependencyRecords.filter((record) => record.phase === 'start'),
+    ).toHaveLength(2)
+    expect(
+      dependencyRecords.filter((record) => record.phase === 'end'),
+    ).toHaveLength(2)
+  })
+
+  it('reports errors caused by an external abort', async () => {
+    const records: TraceRecord[] = []
+    const controller = new AbortController()
+    const abortError = new Error('aborted')
+
+    const result = all(
+      {
+        async pending() {
+          return await new Promise<never>((_resolve, reject) => {
+            this.$signal.addEventListener(
+              'abort',
+              () => reject(this.$signal.reason),
+              { once: true },
+            )
+          })
+        },
+      },
+      {
+        signal: controller.signal,
+        trace: createRecordingTracer(records),
+      },
+    )
+
+    controller.abort(abortError)
+
+    await expect(result).rejects.toBe(abortError)
+    expect(
+      records
+        .filter((record) => record.phase === 'error')
+        .map((record) => record.event),
+    ).toEqual([
+      {
+        type: 'task',
+        operation: 'all',
+        task: 'pending',
+      },
+      {
+        type: 'execution',
+        operation: 'all',
+        tasks: ['pending'],
+      },
+    ])
   })
 
   it('reports rejected tasks and dependency waits in allSettled', async () => {

--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -1,10 +1,35 @@
 import { describe, it, expect, vi, expectTypeOf } from 'vitest'
-import { all, allSettled, flow } from './index'
+import {
+  all,
+  allSettled,
+  flow,
+  type ExecutionTraceEvent,
+  type ExecutionTracer,
+} from './index'
 
 /**
  * Utility function to sleep for a specified number of milliseconds
  */
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+type TraceRecord = {
+  phase: 'start' | 'end' | 'error'
+  event: ExecutionTraceEvent
+}
+
+function createRecordingTracer(records: TraceRecord[]): ExecutionTracer {
+  return async (event, run) => {
+    records.push({ phase: 'start', event })
+    try {
+      const result = await run()
+      records.push({ phase: 'end', event })
+      return result
+    } catch (error) {
+      records.push({ phase: 'error', event })
+      throw error
+    }
+  }
+}
 
 describe('all', () => {
   describe('Basic parallel execution', () => {
@@ -1074,6 +1099,139 @@ describe('allSettled', () => {
         nil: { status: 'fulfilled', value: null },
         undef: { status: 'fulfilled', value: undefined },
       })
+    })
+  })
+})
+
+describe('Tracing', () => {
+  it('traces the execution, tasks, and dependency waits', async () => {
+    const records: TraceRecord[] = []
+
+    const result = await all(
+      {
+        async source() {
+          await sleep(5)
+          return 1
+        },
+        async dependent() {
+          return (await this.$.source) + 1
+        },
+      },
+      { trace: createRecordingTracer(records) },
+    )
+
+    expect(result).toEqual({ source: 1, dependent: 2 })
+
+    const startedEvents = records
+      .filter((record) => record.phase === 'start')
+      .map((record) => record.event)
+    expect(startedEvents).toEqual(
+      expect.arrayContaining([
+        {
+          type: 'execution',
+          operation: 'all',
+          tasks: ['source', 'dependent'],
+        },
+        {
+          type: 'task',
+          operation: 'all',
+          task: 'source',
+        },
+        {
+          type: 'task',
+          operation: 'all',
+          task: 'dependent',
+        },
+        {
+          type: 'dependency-wait',
+          operation: 'all',
+          task: 'dependent',
+          dependency: 'source',
+        },
+      ]),
+    )
+    expect(records.filter((record) => record.phase === 'error')).toEqual([])
+    expect(records.filter((record) => record.phase === 'end')).toHaveLength(
+      startedEvents.length,
+    )
+  })
+
+  it('reports rejected tasks and dependency waits in allSettled', async () => {
+    const records: TraceRecord[] = []
+
+    const result = await allSettled(
+      {
+        async failed() {
+          await sleep(5)
+          throw new Error('failed')
+        },
+        async dependent() {
+          return await this.$.failed
+        },
+      },
+      { trace: createRecordingTracer(records) },
+    )
+
+    expect(result.failed.status).toBe('rejected')
+    expect(result.dependent.status).toBe('rejected')
+
+    const errorEvents = records
+      .filter((record) => record.phase === 'error')
+      .map((record) => record.event)
+    expect(errorEvents).toEqual(
+      expect.arrayContaining([
+        {
+          type: 'task',
+          operation: 'allSettled',
+          task: 'failed',
+        },
+        {
+          type: 'dependency-wait',
+          operation: 'allSettled',
+          task: 'dependent',
+          dependency: 'failed',
+        },
+        {
+          type: 'task',
+          operation: 'allSettled',
+          task: 'dependent',
+        },
+      ]),
+    )
+    expect(records).toContainEqual({
+      phase: 'end',
+      event: {
+        type: 'execution',
+        operation: 'allSettled',
+        tasks: ['failed', 'dependent'],
+      },
+    })
+  })
+
+  it('supports flow without reporting early exit as an error', async () => {
+    const records: TraceRecord[] = []
+
+    const result = await flow<string>(
+      {
+        winner() {
+          this.$end('done')
+        },
+        other() {
+          return 'other'
+        },
+      },
+      { trace: createRecordingTracer(records) },
+    )
+
+    expect(result).toBe('done')
+    expect(records.filter((record) => record.phase === 'error')).toEqual([])
+    expect(records).toContainEqual({
+      phase: 'end',
+      event: {
+        type: 'execution',
+        operation: 'flow',
+        tasks: ['winner', 'other'],
+      },
     })
   })
 })

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -46,10 +46,36 @@ type AllSettledResult<T extends Record<string, (...args: any[]) => any>> = {
   [K in keyof T]: SettledResult<TaskResult<T[K]>>
 }
 
+export type ExecutionOperation = 'all' | 'allSettled' | 'flow'
+
+export type ExecutionTraceEvent =
+  | {
+      type: 'execution'
+      operation: ExecutionOperation
+      tasks: readonly string[]
+    }
+  | {
+      type: 'task'
+      operation: ExecutionOperation
+      task: string
+    }
+  | {
+      type: 'dependency-wait'
+      operation: ExecutionOperation
+      task: string
+      dependency: string
+    }
+
+export type ExecutionTracer = <T>(
+  event: ExecutionTraceEvent,
+  run: () => Promise<T>,
+) => Promise<T>
+
 // Options for all() and allSettled()
 type ExecutionOptions = {
   debug?: boolean
   signal?: AbortSignal
+  trace?: ExecutionTracer
 }
 
 // Internal options for executeTasksInternal
@@ -177,6 +203,11 @@ function executeTasksInternal<T extends Record<string, any>>(
   options: InternalExecutionOptions = {},
 ): Promise<any> {
   const taskNames = Object.keys(tasks) as (keyof T)[]
+  const operation: ExecutionOperation = options.flowMode
+    ? 'flow'
+    : handleSettled
+      ? 'allSettled'
+      : 'all'
   const results = new Map<keyof T, any>()
   const errors = new Map<keyof T, any>()
   const resolvers = new Map<
@@ -218,40 +249,43 @@ function executeTasksInternal<T extends Record<string, any>>(
   >()
 
   const waitForDep = (taskName: keyof T, depName: keyof T): Promise<any> => {
-    if (!(depName in tasks)) {
-      return Promise.reject(new Error(`Unknown task "${String(depName)}"`))
-    }
-
-    // In flow mode, if flow has ended, reject with FlowAbortedError
-    if (options.flowMode && flowEnded) {
-      return Promise.reject(new FlowAbortedError())
-    }
-
-    // Track dependency for debug mode
-    if (options.debug) {
-      if (!taskDependencies.has(taskName)) {
-        taskDependencies.set(taskName, new Set())
+    const executeDependencyWait = (): Promise<any> => {
+      if (!(depName in tasks)) {
+        return Promise.reject(new Error(`Unknown task "${String(depName)}"`))
       }
-      taskDependencies.get(taskName)!.add(String(depName))
-    }
 
-    let basePromise: Promise<any>
+      // In flow mode, if flow has ended, reject with FlowAbortedError
+      if (options.flowMode && flowEnded) {
+        return Promise.reject(new FlowAbortedError())
+      }
 
-    if (results.has(depName)) {
-      basePromise = Promise.resolve(results.get(depName))
-    } else if (errors.has(depName)) {
-      basePromise = Promise.reject(errors.get(depName))
-    } else {
-      basePromise = new Promise((resolve, reject) => {
-        if (!resolvers.has(depName)) {
-          resolvers.set(depName, [])
+      // Track dependency for debug mode
+      if (options.debug) {
+        if (!taskDependencies.has(taskName)) {
+          taskDependencies.set(taskName, new Set())
         }
-        resolvers.get(depName)!.push([resolve, reject])
-      })
-    }
+        taskDependencies.get(taskName)!.add(String(depName))
+      }
 
-    // Wrap promise to track wait time in debug mode
-    if (options.debug) {
+      let basePromise: Promise<any>
+
+      if (results.has(depName)) {
+        basePromise = Promise.resolve(results.get(depName))
+      } else if (errors.has(depName)) {
+        basePromise = Promise.reject(errors.get(depName))
+      } else {
+        basePromise = new Promise((resolve, reject) => {
+          if (!resolvers.has(depName)) {
+            resolvers.set(depName, [])
+          }
+          resolvers.get(depName)!.push([resolve, reject])
+        })
+      }
+
+      if (!options.debug) {
+        return basePromise
+      }
+
       const waitStart = performance.now()
       return basePromise.then(
         (value) => {
@@ -277,7 +311,19 @@ function executeTasksInternal<T extends Record<string, any>>(
       )
     }
 
-    return basePromise
+    if (!options.trace) {
+      return executeDependencyWait()
+    }
+
+    return options.trace(
+      {
+        type: 'dependency-wait',
+        operation,
+        task: String(taskName),
+        dependency: String(depName),
+      },
+      executeDependencyWait,
+    )
   }
 
   const handleResult = (name: keyof T, value: any) => {
@@ -307,100 +353,120 @@ function executeTasksInternal<T extends Record<string, any>>(
   }
 
   // Run all tasks in parallel
-  const promises = taskNames.map(async (name) => {
-    try {
-      const taskFn = tasks[name]
-      if (typeof taskFn !== 'function') {
-        throw new Error(`Task "${String(name)}" is not a function`)
-      }
+  const promises = taskNames.map((name) => {
+    const executeTask = async () => {
+      try {
+        const taskFn = tasks[name]
+        if (typeof taskFn !== 'function') {
+          throw new Error(`Task "${String(name)}" is not a function`)
+        }
 
-      // Track start time for debug mode
-      if (options.debug) {
-        taskStartTimes.set(name, performance.now())
-      }
+        // Track start time for debug mode
+        if (options.debug) {
+          taskStartTimes.set(name, performance.now())
+        }
 
-      // Create a unique dep proxy for each task to track dependencies
-      const depProxy = new Proxy({} as DepProxy<T>, {
-        get(_, depName: string) {
-          return waitForDep(name, depName as keyof T)
-        },
-      })
+        // Create a unique dep proxy for each task to track dependencies
+        const depProxy = new Proxy({} as DepProxy<T>, {
+          get(_, depName: string) {
+            return waitForDep(name, depName as keyof T)
+          },
+        })
 
-      // Create $end function for flow mode
-      const $end = options.flowMode
-        ? (value: any): never => {
-            if (!flowEnded) {
-              flowEnded = true
-              flowEndValue = value
+        // Create $end function for flow mode
+        const $end = options.flowMode
+          ? (value: any): never => {
+              if (!flowEnded) {
+                flowEnded = true
+                flowEndValue = value
+              }
+              throw new FlowEndError(value)
             }
-            throw new FlowEndError(value)
+          : undefined
+
+        const context: any = {
+          $: depProxy,
+          $signal: internalController.signal,
+        }
+
+        if (options.flowMode && $end) {
+          context.$end = $end
+        }
+
+        const result = await taskFn.call(context)
+
+        // Track end time and create timing record
+        if (options.debug) {
+          const endTime = performance.now()
+          const startTime = taskStartTimes.get(name)!
+          timings.push({
+            name: String(name),
+            startTime,
+            endTime,
+            duration: endTime - startTime,
+            dependencies: Array.from(taskDependencies.get(name) || []),
+            status: 'fulfilled',
+            waitPeriods: taskWaitPeriods.get(name) || [],
+          })
+        }
+
+        handleResult(name, result)
+      } catch (err) {
+        // In flow mode, handle FlowEndError and FlowAbortedError specially
+        if (options.flowMode) {
+          if (err instanceof FlowEndError) {
+            // This is intentional early exit, don't propagate as error.
+            // Reject pending resolvers so dependent tasks don't hang forever.
+            handleError(name, new FlowAbortedError())
+            return
           }
-        : undefined
-
-      const context: any = {
-        $: depProxy,
-        $signal: internalController.signal,
-      }
-
-      if (options.flowMode && $end) {
-        context.$end = $end
-      }
-
-      const result = await taskFn.call(context)
-
-      // Track end time and create timing record
-      if (options.debug) {
-        const endTime = performance.now()
-        const startTime = taskStartTimes.get(name)!
-        timings.push({
-          name: String(name),
-          startTime,
-          endTime,
-          duration: endTime - startTime,
-          dependencies: Array.from(taskDependencies.get(name) || []),
-          status: 'fulfilled',
-          waitPeriods: taskWaitPeriods.get(name) || [],
-        })
-      }
-
-      handleResult(name, result)
-    } catch (err) {
-      // In flow mode, handle FlowEndError and FlowAbortedError specially
-      if (options.flowMode) {
-        if (err instanceof FlowEndError) {
-          // This is intentional early exit, don't propagate as error.
-          // Reject pending resolvers so dependent tasks don't hang forever.
-          handleError(name, new FlowAbortedError())
-          return
+          if (err instanceof FlowAbortedError) {
+            // Flow was ended by another task, silently ignore
+            return
+          }
         }
-        if (err instanceof FlowAbortedError) {
-          // Flow was ended by another task, silently ignore
-          return
+
+        // Track end time for failed tasks too
+        if (options.debug) {
+          const endTime = performance.now()
+          const startTime = taskStartTimes.get(name)!
+          timings.push({
+            name: String(name),
+            startTime,
+            endTime,
+            duration: endTime - startTime,
+            dependencies: Array.from(taskDependencies.get(name) || []),
+            status: 'rejected',
+            waitPeriods: taskWaitPeriods.get(name) || [],
+          })
         }
-      }
 
-      // Track end time for failed tasks too
-      if (options.debug) {
-        const endTime = performance.now()
-        const startTime = taskStartTimes.get(name)!
-        timings.push({
-          name: String(name),
-          startTime,
-          endTime,
-          duration: endTime - startTime,
-          dependencies: Array.from(taskDependencies.get(name) || []),
-          status: 'rejected',
-          waitPeriods: taskWaitPeriods.get(name) || [],
-        })
-      }
-
-      handleError(name, err)
-      if (!handleSettled) {
-        // Abort other tasks when one fails (only for all(), not allSettled())
-        internalController.abort(err)
-        throw err
+        handleError(name, err)
+        if (!handleSettled) {
+          // Abort other tasks when one fails (only for all(), not allSettled())
+          internalController.abort(err)
+          throw err
+        }
+        if (options.trace) {
+          // Let the tracing wrapper observe the rejection. allSettled still
+          // converts the task promise into its settled return value below.
+          throw err
+        }
       }
     }
+
+    if (!options.trace) {
+      return executeTask()
+    }
+
+    return options.trace(
+      {
+        type: 'task',
+        operation,
+        task: String(name),
+      },
+      executeTask,
+    )
   })
 
   const finalPromise = options.flowMode
@@ -506,7 +572,21 @@ export function all<T extends Record<string, any>>(
     },
   options?: ExecutionOptions,
 ): Promise<AllResult<T>> {
-  return executeTasksInternal(tasks, false, options) as Promise<AllResult<T>>
+  const execute = () =>
+    executeTasksInternal(tasks, false, options) as Promise<AllResult<T>>
+
+  if (!options?.trace) {
+    return execute()
+  }
+
+  return options.trace(
+    {
+      type: 'execution',
+      operation: 'all',
+      tasks: Object.keys(tasks),
+    },
+    execute,
+  )
 }
 
 /**
@@ -544,9 +624,21 @@ export function allSettled<T extends Record<string, any>>(
     },
   options?: ExecutionOptions,
 ): Promise<AllSettledResult<T>> {
-  return executeTasksInternal(tasks, true, options) as Promise<
-    AllSettledResult<T>
-  >
+  const execute = () =>
+    executeTasksInternal(tasks, true, options) as Promise<AllSettledResult<T>>
+
+  if (!options?.trace) {
+    return execute()
+  }
+
+  return options.trace(
+    {
+      type: 'execution',
+      operation: 'allSettled',
+      tasks: Object.keys(tasks),
+    },
+    execute,
+  )
 }
 
 /**
@@ -644,8 +736,22 @@ export function flow<R, T extends Record<string, any> = Record<string, any>>(
     },
   options?: ExecutionOptions,
 ): Promise<R | undefined> {
-  return executeTasksInternal(tasks, false, {
-    ...options,
-    flowMode: true,
-  }) as Promise<R | undefined>
+  const execute = () =>
+    executeTasksInternal(tasks, false, {
+      ...options,
+      flowMode: true,
+    }) as Promise<R | undefined>
+
+  if (!options?.trace) {
+    return execute()
+  }
+
+  return options.trace(
+    {
+      type: 'execution',
+      operation: 'flow',
+      tasks: Object.keys(tasks),
+    },
+    execute,
+  )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,8 @@
-export { all, allSettled, flow } from '../lib/index'
+export {
+  all,
+  allSettled,
+  flow,
+  type ExecutionOperation,
+  type ExecutionTraceEvent,
+  type ExecutionTracer,
+} from '../lib/index'


### PR DESCRIPTION
## Summary

Adds an optional `trace` hook for observing how `all`, `allSettled`, and `flow` execute.

## Problem

Debug mode is useful for inspecting a completed run, but it cannot connect task execution to an application's existing tracing setup. There is currently no way to create nested spans for the overall run, individual tasks, or the time spent waiting on dependencies.

## Solution

The new `trace(event, run)` hook wraps each observable part of the execution:

- the complete `all`, `allSettled`, or `flow` call
- each task
- each dependency wait

The wrapper shape lets tracing adapters preserve async context and create correctly nested spans without coupling the package to a specific tracing library. Events include the operation and relevant task names, while existing return values, failures, `allSettled` behavior, and `flow` early exits remain unchanged.

The tracing types are exported, and the README includes an OpenTelemetry adapter using active spans, stable span names, and task details as attributes.

## Testing

- `pnpm test` — 112 tests covering async parent context, success and failure paths, dependency waits, repeated dependency access, external aborts, `allSettled`, and `flow`
- `pnpm build`
- `pnpm exec tsc --noEmit`
